### PR TITLE
Fix About us menu path

### DIFF
--- a/src/pages/menu.js
+++ b/src/pages/menu.js
@@ -55,7 +55,7 @@ const menus = [
     {
         id: 6,
         name: 'About us',
-        links: 'aboutUs', 
+        links: '/aboutUs',
     },
     
 ]


### PR DESCRIPTION
## Summary
- fix link path for the About us menu entry

## Testing
- `npm test -- -w=1` *(fails: react-scripts not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68446ee57820832880c687e8eae18f37