### PR TITLE
Use env vars for Firebase config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Copy this file to `.env` and replace the values with your Firebase credentials
+
+REACT_APP_FIREBASE_API_KEY=your_api_key
+REACT_APP_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
+REACT_APP_FIREBASE_PROJECT_ID=your_project_id
+REACT_APP_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
+REACT_APP_FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+REACT_APP_FIREBASE_APP_ID=your_app_id

--- a/README.md
+++ b/README.md
@@ -31,3 +31,23 @@
 - **Productivity:** Enhance productivity by tracking usage and managing resources effectively.
 - **Security:** Securely manage credentials and sensitive information.
 - **Customization:** Tailor the platform to fit your specific needs and workflows.
+
+## Environment Configuration
+
+The Firebase credentials used by the application are loaded from environment variables.
+Create a copy of `.env.example` named `.env` and replace the placeholder values
+with your Firebase project configuration:
+
+```bash
+cp .env.example .env
+# then edit .env with your credentials
+```
+
+The following variables must be provided:
+
+- `REACT_APP_FIREBASE_API_KEY`
+- `REACT_APP_FIREBASE_AUTH_DOMAIN`
+- `REACT_APP_FIREBASE_PROJECT_ID`
+- `REACT_APP_FIREBASE_STORAGE_BUCKET`
+- `REACT_APP_FIREBASE_MESSAGING_SENDER_ID`
+- `REACT_APP_FIREBASE_APP_ID`

--- a/src/configs/firebase.js
+++ b/src/configs/firebase.js
@@ -2,12 +2,12 @@ import { initializeApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 
 const firebaseConfig = {
-  apiKey: "AIzaSyBAFbZc9ln8hD_lY9Yr42U4ej1Lv7cIZRA",
-  authDomain: "hyperlink-9585b.firebaseapp.com",
-  projectId: "hyperlink-9585b",
-  storageBucket: "hyperlink-9585b.appspot.com",
-  messagingSenderId: "73773902197",
-  appId: "1:73773902197:web:b7179c4d95cdf904b1cb3c",
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_FIREBASE_APP_ID,
 };
 
 // Initialize Firebase


### PR DESCRIPTION
## Summary
- read Firebase credentials from environment variables
- provide `.env.example` with required variables
- document Firebase environment setup

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68446f65510483289ad471ac630e3ecc