### PR TITLE
Fix typo in Login page

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -71,7 +71,7 @@ function Login() {
                     </fieldset>
                   </div>
                   <Link to="/forgetPass" className="fogot-pass">
-                    Fogot password?
+                    Forgot password?
                   </Link>
                 </div>
 


### PR DESCRIPTION
## Summary
- correct typo in forgot password link on Login page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447c712df08328a958463489499371