### PR TITLE
Add descriptive alt text for images

### DIFF
--- a/src/pages/BlogDetails.jsx
+++ b/src/pages/BlogDetails.jsx
@@ -112,7 +112,7 @@ function BlogDetails() {
                     <div className="image">
                       <img
                         src={require("../assets/images/post/post_25.png")}
-                        alt=""
+                        alt="Meta promotional image"
                       />
                       <p>Image courtesy of Meta</p>
                     </div>
@@ -194,7 +194,7 @@ function BlogDetails() {
                     <div className="image mb12">
                       <img
                         src={require("../assets/images/post/post_29.png")}
-                        alt=""
+                        alt="Product demonstration at Meta Connect 2022"
                       />
                       <p>Product demonstration at Meta Connect 2022</p>
                     </div>
@@ -305,7 +305,7 @@ function BlogDetails() {
                       <div className="image">
                         <img
                           src={require("../assets/images/post/post_20.png")}
-                          alt=""
+                          alt="Meta Is Still Betting on a VR Revolution That May Never Come thumbnail"
                         />
                       </div>
                       <div className="content">
@@ -339,7 +339,7 @@ function BlogDetails() {
                       <div className="image">
                         <img
                           src={require("../assets/images/post/post_21.png")}
-                          alt=""
+                          alt="Meta’s VR Headset Harvests Personal Data Right Off Your... thumbnail"
                         />
                       </div>
                       <div className="content">
@@ -373,7 +373,7 @@ function BlogDetails() {
                       <div className="image">
                         <img
                           src={require("../assets/images/post/post_22.png")}
-                          alt=""
+                          alt="VR Still Stinks Because It Doesn’t Smell thumbnail"
                         />
                       </div>
                       <div className="content">
@@ -406,7 +406,7 @@ function BlogDetails() {
                       <div className="image">
                         <img
                           src={require("../assets/images/post/post_23.png")}
-                          alt=""
+                          alt="How China Threatens to Splinter the Metaverse thumbnail"
                         />
                       </div>
                       <div className="content">
@@ -439,7 +439,7 @@ function BlogDetails() {
                       <div className="image">
                         <img
                           src={require("../assets/images/post/post_24.png")}
-                          alt=""
+                          alt="It's Not Too Late to Save the Metaverse thumbnail"
                         />
                       </div>
                       <div className="content">

--- a/src/pages/Blogs.jsx
+++ b/src/pages/Blogs.jsx
@@ -24,7 +24,7 @@ function Blogs() {
               <div key={item.id} className="col-lg-4 col-md-12">
                 <div className="grid-box">
                   <div className="image">
-                    <img src={item.img} alt="" />
+                    <img src={item.img} alt={item.heading} />
                   </div>
                   <div className="content">
                     <Link to={`/blogs/${i}`} className="tag">

--- a/src/pages/InnerToolbox.jsx
+++ b/src/pages/InnerToolbox.jsx
@@ -50,9 +50,9 @@ const InnerToolbox = () => {
                   >
                     <div className="header_project">
                       <div className="image">
-                        <img className="mask" src={item.img} alt="" />
+                        <img className="mask" src={item.img} alt={item.actualName} />
                         <div className="shape">
-                          <img src={""} alt="" />
+                          <img src={""} alt="Decorative shape" />
                         </div>
                       </div>
                       <h5 className="heading">

--- a/src/pages/ProjectDetails.jsx
+++ b/src/pages/ProjectDetails.jsx
@@ -31,10 +31,10 @@ function ProjectDetails() {
                     <img
                       className="mask"
                       src={require("../assets/images/common/canva.webp")}
-                      alt=""
+                      alt="Screenshot of Canva tool"
                     />
                     <div className="shape">
-                      <img src={""} alt="" />
+                      <img src={""} alt="Decorative shape" />
                     </div>
                   </div>
                   <div className="content">
@@ -109,7 +109,7 @@ function ProjectDetails() {
                   </li>
                 </ul>
                 <div className="image mb30">
-                  <img className="boder-20" alt="" />
+                  <img className="boder-20" alt="Project preview" />
                 </div>
                 <div className="box">
                   <h4 className="heading mb10">1. Project overview</h4>

--- a/src/pages/Roadmap.jsx
+++ b/src/pages/Roadmap.jsx
@@ -51,7 +51,7 @@ function Roadmap() {
                         className={`roadmap-box-style ${item.status}`}
                       >
                         <div className="icon">
-                          <img src={icon} alt="" />
+                          <img src={icon} alt="Roadmap milestone icon" />
                         </div>
                         <div className="content">
                           <h6 className="date">{item.time}</h6>
@@ -73,7 +73,7 @@ function Roadmap() {
                         className={`roadmap-box-style ${item.status}`}
                       >
                         <div className="icon">
-                          <img src={icon} alt="" />
+                          <img src={icon} alt="Roadmap milestone icon" />
                         </div>
                         <div className="content">
                           <h6 className="date">{item.time}</h6>
@@ -101,7 +101,7 @@ function Roadmap() {
                         className={`roadmap-box-style ${item.status}`}
                       >
                         <div className="icon">
-                          <img src={icon} alt="" />
+                          <img src={icon} alt="Roadmap milestone icon" />
                         </div>
                         <div className="content">
                           <h6 className="date">{item.time}</h6>

--- a/src/pages/TeamDetails.jsx
+++ b/src/pages/TeamDetails.jsx
@@ -102,7 +102,7 @@ function UserDashboard(props) {
                           <li>
                             <img
                               src={require("../assets/images/chart/color_1.png")}
-                              alt=""
+                              alt="Farming Pool segment"
                             />
                             <div className="desc">
                               <p className="name">Farming Pool</p>
@@ -112,7 +112,7 @@ function UserDashboard(props) {
                           <li>
                             <img
                               src={require("../assets/images/chart/color_2.png")}
-                              alt=""
+                              alt="Staking segment"
                             />
                             <div className="desc">
                               <p className="name">Staking</p>
@@ -122,7 +122,7 @@ function UserDashboard(props) {
                           <li>
                             <img
                               src={require("../assets/images/chart/color_3.png")}
-                              alt=""
+                              alt="Ecosystem segment"
                             />
                             <div className="desc">
                               <p className="name">Ecosystem</p>
@@ -132,7 +132,7 @@ function UserDashboard(props) {
                           <li>
                             <img
                               src={require("../assets/images/chart/color_4.png")}
-                              alt=""
+                              alt="Advisor segment"
                             />
                             <div className="desc">
                               <p className="name">Advisor</p>
@@ -142,7 +142,7 @@ function UserDashboard(props) {
                           <li>
                             <img
                               src={require("../assets/images/chart/color_5.png")}
-                              alt=""
+                              alt="Private Sale segment"
                             />
                             <div className="desc">
                               <p className="name">Private Sale</p>
@@ -152,7 +152,7 @@ function UserDashboard(props) {
                           <li>
                             <img
                               src={require("../assets/images/chart/color_6.png")}
-                              alt=""
+                              alt="Liquidity segment"
                             />
                             <div className="desc">
                               <p className="name">Liquidity</p>
@@ -162,7 +162,7 @@ function UserDashboard(props) {
                           <li>
                             <img
                               src={require("../assets/images/chart/color_7.png")}
-                              alt=""
+                              alt="Marketing segment"
                             />
                             <div className="desc">
                               <p className="name">Marketing</p>
@@ -172,7 +172,7 @@ function UserDashboard(props) {
                           <li>
                             <img
                               src={require("../assets/images/chart/color_8.png")}
-                              alt=""
+                              alt="Team segment"
                             />
                             <div className="desc">
                               <p className="name">Team</p>

--- a/src/pages/aboutUs.jsx
+++ b/src/pages/aboutUs.jsx
@@ -65,7 +65,7 @@ const AboutUs = () => {
                             data-aos-duration="800"
                           >
                             <div className="image">
-                              <img src={data.img} alt="" />
+                              <img src={data.img} alt={data.name} />
                             </div>
                             <div className="content">
                               <h5 className="name">


### PR DESCRIPTION
## Summary
- replace empty alt attributes in `src/pages` with descriptive text

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447cd530608328bfe7b85af3e30582