### PR TITLE
Remove loader timeout in AuthContext

### DIFF
--- a/src/context/authContext.jsx
+++ b/src/context/authContext.jsx
@@ -10,19 +10,10 @@ export const AuthContextProvider = ({ children }) => {
   const [currentUser, setCurrentUser] = useState(null);
   const [loading, setLoading] = useState(true);
 
-
-    // Simulate a loading delay of 3 seconds
-    useEffect(() => {
-      const timer = setTimeout(() => {
-        setLoading(false);
-      }, 4000);
-  
-      return () => clearTimeout(timer);
-    }, []);
-
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged((user) => {
       setCurrentUser(user);
+      setLoading(false);
     });
 
     return () => {


### PR DESCRIPTION
## Summary
- remove artificial loading timeout from `AuthContext`
- end the loading state when `onAuthStateChanged` fires

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447edb46208328b4bb00c56945930c