### PR TITLE
Clarify loader end condition

### DIFF
--- a/src/context/authContext.jsx
+++ b/src/context/authContext.jsx
@@ -10,6 +10,7 @@ export const AuthContextProvider = ({ children }) => {
   const [currentUser, setCurrentUser] = useState(null);
   const [loading, setLoading] = useState(true);
 
+  // Once Firebase confirms the user state, stop showing the loader
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged((user) => {
       setCurrentUser(user);


### PR DESCRIPTION
## Summary
- add a comment noting that loading ends once Firebase reports the user state

## Testing
- `npm test --silent` *(fails: react-scripts not found)*


------
https://chatgpt.com/codex/tasks/task_e_684483ff020483288067f0972f25bd72