### PR TITLE
Fix redirect check in toolbox page

### DIFF
--- a/src/pages/InnerToolbox.jsx
+++ b/src/pages/InnerToolbox.jsx
@@ -21,7 +21,7 @@ const InnerToolbox = () => {
     if (!toolboxesList.includes(pageTitle)) {
       navigate("/");
     }
-  }, []);
+  }, [pageTitle, navigate]);
 
   return (
     <div className="inner-page project-grid-5">


### PR DESCRIPTION
## Summary
- update InnerToolbox to watch `pageTitle` and `navigate`

## Testing
- `npm run lint`
- `CI=true npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684484d4e5f883288d6d549e14d047d1