### PR TITLE
Improve route loading with React.lazy

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,12 @@
-import { React, useEffect } from "react";
+import React, { useEffect, Suspense, lazy } from "react";
 import { Route, Routes } from "react-router-dom";
 import AOS from "aos";
 import routes from "./pages";
 import "../src/assets/fonts/font-awesome.css";
-import Header from "./components/header";
-import Footer from "./components/footer";
+import Loader from "./components/Loader";
+
+const Header = lazy(() => import("./components/header"));
+const Footer = lazy(() => import("./components/footer"));
 import "./scss/component/_section.scss";
 import "./scss/component/_box.scss";
 import "./scss/component/_tf-section.scss";
@@ -18,16 +20,22 @@ function App() {
   }, []);
   return (
     <>
-      <Header />
+      <Suspense fallback={<Loader />}>
+        <Header />
+      </Suspense>
 
-      <Routes>
-        {routes.map((data, idx) => (
-          <Route key={idx} path={data.path} element={data.component} exact />
-        ))}
-        <Route path="*" element={<NotFound />} />
-      </Routes>
+      <Suspense fallback={<Loader />}>
+        <Routes>
+          {routes.map((data, idx) => (
+            <Route key={idx} path={data.path} element={data.component} exact />
+          ))}
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Suspense>
 
-      <Footer />
+      <Suspense fallback={<Loader />}>
+        <Footer />
+      </Suspense>
     </>
   );
 }

--- a/src/components/Loader.jsx
+++ b/src/components/Loader.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+const Loader = () => (
+  <div className="d-flex justify-content-center align-items-center" style={{ minHeight: "100vh" }}>
+    <div className="spinner-border text-primary" role="status">
+      <span className="visually-hidden">Loading...</span>
+    </div>
+  </div>
+);
+
+export default Loader;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,17 +1,19 @@
-import Home from "./Home";
-import ProjectDetails from "./ProjectDetails";
-import UserDashboard from "./TeamDetails";
+import React, { lazy } from "react";
 import "../components/button/styles.scss";
 
-import Login from "./Login";
-import Register from "./Register";
-import ForgetPass from "./ForgetPass";
-import Roadmap from "./Roadmap";
-import Blogs from "./Blogs";
-import BlogDetails from "./BlogDetails";
-import Contact from "./Contact";
-import InnerToolbox from "./InnerToolbox";
-import AboutUs from "./aboutUs";
+const Home = lazy(() => import("./Home"));
+const ProjectDetails = lazy(() => import("./ProjectDetails"));
+const UserDashboard = lazy(() => import("./TeamDetails"));
+
+const Login = lazy(() => import("./Login"));
+const Register = lazy(() => import("./Register"));
+const ForgetPass = lazy(() => import("./ForgetPass"));
+const Roadmap = lazy(() => import("./Roadmap"));
+const Blogs = lazy(() => import("./Blogs"));
+const BlogDetails = lazy(() => import("./BlogDetails"));
+const Contact = lazy(() => import("./Contact"));
+const InnerToolbox = lazy(() => import("./InnerToolbox"));
+const AboutUs = lazy(() => import("./aboutUs"));
 
 const routes = [
   { path: "/login", component: <Login /> },


### PR DESCRIPTION
## Summary
- add a small Loader component
- lazy load Header and Footer
- lazy load page components

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run build` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449c3ad0f483289782af51b803777f