### PR TITLE
Add Firebase auth error handling

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -9,6 +9,7 @@ function Login() {
   const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
 
   const onLogin = (e) => {
     e.preventDefault();
@@ -21,8 +22,12 @@ function Login() {
       })
       .catch((error) => {
         const errorCode = error.code;
-        const errorMessage = error.message;
-        console.log(errorCode, errorMessage);
+        const messages = {
+          "auth/wrong-password": "Incorrect email or password.",
+          "auth/user-not-found": "No account found with this email.",
+          "auth/too-many-requests": "Too many failed attempts. Try again later.",
+        };
+        setError(messages[errorCode] || "Failed to login. Please try again.");
       });
   };
 
@@ -80,6 +85,11 @@ function Login() {
                     Login
                   </button>
                 </div>
+                {error && (
+                  <p style={{ color: "red" }} className="error">
+                    {error}
+                  </p>
+                )}
               </form>
             </div>
           </div>

--- a/src/pages/__tests__/Login.test.js
+++ b/src/pages/__tests__/Login.test.js
@@ -1,11 +1,17 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 
 // Mock Firebase config and auth functions
 jest.mock('../../configs/firebase', () => ({ auth: {} }));
+const signInMock = jest.fn();
 jest.mock('firebase/auth', () => ({
-  signInWithEmailAndPassword: jest.fn(),
+  signInWithEmailAndPassword: (...args) => signInMock(...args),
 }));
+
+beforeEach(() => {
+  signInMock.mockReset();
+});
 
 import Login from '../Login';
 
@@ -20,4 +26,22 @@ test('renders login form', () => {
   expect(screen.getByPlaceholderText('Your email')).toBeInTheDocument();
   expect(screen.getByPlaceholderText('Your password')).toBeInTheDocument();
   expect(screen.getByRole('button', { name: /Login/i })).toBeInTheDocument();
+});
+
+test('shows error message for wrong password', async () => {
+  signInMock.mockRejectedValue({ code: 'auth/wrong-password' });
+
+  render(
+    <MemoryRouter>
+      <Login />
+    </MemoryRouter>
+  );
+
+  await userEvent.type(screen.getByPlaceholderText('Your email'), 'user@example.com');
+  await userEvent.type(screen.getByPlaceholderText('Your password'), 'badpass');
+  userEvent.click(screen.getByRole('button', { name: /Login/i }));
+
+  await waitFor(() =>
+    expect(screen.getByText('Incorrect email or password.')).toBeInTheDocument()
+  );
 });

--- a/src/pages/__tests__/Login.test.js
+++ b/src/pages/__tests__/Login.test.js
@@ -4,14 +4,14 @@ import { MemoryRouter } from 'react-router-dom';
 
 // Mock Firebase config and auth functions
 jest.mock('../../configs/firebase', () => ({ auth: {} }));
-const signInMock = jest.fn();
-jest.mock('firebase/auth', () => ({
-  signInWithEmailAndPassword: (...args) => signInMock(...args),
-}));
-
-beforeEach(() => {
-  signInMock.mockReset();
+jest.mock('firebase/auth', () => {
+  const signInMock = jest.fn();
+  return {
+    signInWithEmailAndPassword: signInMock,
+    __esModule: true,
+  };
 });
+
 
 import Login from '../Login';
 
@@ -29,7 +29,8 @@ test('renders login form', () => {
 });
 
 test('shows error message for wrong password', async () => {
-  signInMock.mockRejectedValue({ code: 'auth/wrong-password' });
+  const { signInWithEmailAndPassword } = require('firebase/auth');
+  signInWithEmailAndPassword.mockRejectedValue({ code: 'auth/wrong-password' });
 
   render(
     <MemoryRouter>


### PR DESCRIPTION
## Summary
- display Firebase auth errors in Login form
- test incorrect password message

## Testing
- `npm test --silent` *(fails: Cannot find module 'react' for TS type check)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*


------
https://chatgpt.com/codex/tasks/task_e_68449dde30108328863c0f709bb516fa